### PR TITLE
Debug expo ios app crash on launch

### DIFF
--- a/calrecorder/src/services/background.js
+++ b/calrecorder/src/services/background.js
@@ -4,14 +4,19 @@ import { performDailyRollover } from './rollover';
 
 export const ROLLOVER_TASK = 'daily-rollover-task';
 
-TaskManager.defineTask(ROLLOVER_TASK, async () => {
-  try {
-    await performDailyRollover();
-    return BackgroundFetch.BackgroundFetchResult.NewData;
-  } catch (e) {
-    return BackgroundFetch.BackgroundFetchResult.Failed;
-  }
-});
+// Guard task definition so Expo Go or unsupported runtimes don't crash on import
+try {
+  TaskManager.defineTask(ROLLOVER_TASK, async () => {
+    try {
+      await performDailyRollover();
+      return BackgroundFetch.BackgroundFetchResult.NewData;
+    } catch (e) {
+      return BackgroundFetch.BackgroundFetchResult.Failed;
+    }
+  });
+} catch (e) {
+  // ignore if TaskManager is unavailable
+}
 
 export async function registerBackgroundTask() {
   try {


### PR DESCRIPTION
Wrap `TaskManager.defineTask` in a try/catch to prevent crashes in environments where `expo-task-manager` is unavailable.

The app was crashing on iOS launch in Expo Go because `TaskManager.defineTask` was called at module load, which throws an `UnavailabilityError` when `expo-task-manager` is not available. This change prevents the crash by gracefully handling the unavailability.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f70dd92-07a6-4342-8a50-a2360cd075ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f70dd92-07a6-4342-8a50-a2360cd075ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

