### PR TITLE
Investigate app crash on load

### DIFF
--- a/calrecorder/App.js
+++ b/calrecorder/App.js
@@ -4,7 +4,7 @@ import DashboardScreen from './src/screens/DashboardScreen';
 import AddEntryScreen from './src/screens/AddEntryScreen';
 import GoalSettingScreen from './src/screens/GoalSettingScreen';
 import CalendarScreen from './src/screens/CalendarScreen';
-import { Pressable, Text } from 'react-native';
+import { Pressable, Text, Platform } from 'react-native';
 import { useEffect } from 'react';
 import { performDailyRollover } from './src/services/rollover';
 import { registerBackgroundTask } from './src/services/background';
@@ -30,7 +30,9 @@ function HeaderRight({ navigation }) {
 export default function App() {
   useEffect(() => {
     performDailyRollover();
-    registerBackgroundTask();
+    if (Platform.OS !== 'web') {
+      registerBackgroundTask();
+    }
   }, []);
   return (
     <NavigationContainer>


### PR DESCRIPTION
Conditionally register background tasks and dynamically import related modules to prevent crashes on web and unsupported platforms.

The app was crashing on startup when run on the web platform. This was traced to the `expo-task-manager` and `expo-background-fetch` modules being initialized and defining tasks in environments where they are not supported, leading to runtime errors. The changes ensure these modules are only loaded and tasks defined on native platforms.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d4f7afc-a232-4d83-a278-6972610556f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9d4f7afc-a232-4d83-a278-6972610556f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

